### PR TITLE
[feature/USE-RSYNC] Uses rsync instead of cp

### DIFF
--- a/replace.sh
+++ b/replace.sh
@@ -43,5 +43,5 @@ if [ -d ${PACKAGE}/.${MODULE} ]; then
 else
     echo -e "${INFO} Prepping ${PACKAGE} for ${MODULE}"
     mv ${PACKAGE}/${MODULE} ${PACKAGE}/.${MODULE}
-    cp -r ${PREFIX}-${MODULE} ${PACKAGE}/${MODULE}
+    rsync -av ${PREFIX}-${MODULE} ${PACKAGE}/${MODULE} --exclude .git
 fi


### PR DESCRIPTION
rsync is much faster and allows us to exclude files and folders
if needed like .git. So if someone forgets to restore their modeule
they can still run npm install on their package without getting
any errors or warnings.